### PR TITLE
Hide tooltips on mobile

### DIFF
--- a/src/components/ui/IconWithTooltip.tsx
+++ b/src/components/ui/IconWithTooltip.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import Link from "next/link";
+import { useScreenSize } from "@/app/hooks/useScreenSize";
 
 export default function IconWithTooltip({
     icon, 
@@ -20,6 +21,8 @@ export default function IconWithTooltip({
     disabled?: boolean
 }){
 
+    const {isMedium} = useScreenSize()
+
     const Icon = 
         <div className="font-sans relative group inline-block">
             <FontAwesomeIcon 
@@ -27,7 +30,7 @@ export default function IconWithTooltip({
                 className={`${extraClass} ${danger ? 'text-orange-500': disabled? 'text-gray-400': 'cursor-pointer'} hover:animate-pulse`} 
                 onClick={disabled ? () => {} : onClick}
             />
-            {!disabled && <span 
+            {!disabled && !isMedium && <span 
                 className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2
                     opacity-0 group-hover:opacity-100 transition
                     bg-yellow-200 text-gray-800 text-xs px-2 py-1 shadow rotate-1 whitespace-nowrap"


### PR DESCRIPTION
Updated IconWithTooltip using screen size hook to conditionally render tooltip text