### PR TITLE
Fix/theme match case insensitive

### DIFF
--- a/src/components/dreams/DreamForm.tsx
+++ b/src/components/dreams/DreamForm.tsx
@@ -38,10 +38,24 @@ export default function DreamForm({
 
     const handleChangeCurrentTheme = (event: React.ChangeEvent<HTMLInputElement>) => {
         const value = event.target.value.trim()
+        const normalizedValue = value.toLowerCase()
+
+        const normalizedSuggestions = suggestions.map(s => s.toLowerCase())
+        const normalizedThemes = themes.map(t => t.toLowerCase())
+
         setCurrentTheme(value)
-        setShowSuggestions(!suggestions.includes(value) && value !== '' && suggestions.length > 0)
+        setShowSuggestions(
+            !normalizedSuggestions.includes(normalizedValue) &&
+            value !== '' &&
+            suggestions.length > 0
+        )
+
         setMsg('')
-        setVisible(!themes.includes(value) && value !== '')
+
+        setVisible(
+            !normalizedThemes.includes(normalizedValue) &&
+            value !== ''
+        )
     }
 
     const addTheme = () => {

--- a/src/components/dreams/DreamForm.tsx
+++ b/src/components/dreams/DreamForm.tsx
@@ -37,7 +37,7 @@ export default function DreamForm({
     }
 
     const handleChangeCurrentTheme = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const value = event.target.value.trim()
+        const value = event.target.value
         const normalizedValue = value.toLowerCase()
 
         const normalizedSuggestions = suggestions.map(s => s.toLowerCase())

--- a/src/components/themes/BlankLabel.tsx
+++ b/src/components/themes/BlankLabel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useDreamView } from "@/contexts/DreamViewContext"
 import { getColorForTheme } from "@/lib/utils/getColorForTheme"
 import { useScreenSize } from "@/app/hooks/useScreenSize"
@@ -7,24 +7,34 @@ export default function BlankLabel ({
 
 }) {
     const [newTheme, setNewTheme] = useState({text: '', color: ''})
+    const [canAdd, setCanAdd] = useState(false)
     const { themes, setShowBlankLabel, addTheme } = useDreamView()
+    const normalizedThemes = themes.map(t => t.toLowerCase())
 
     const defaultColor = 'bg-gray-300'
-
+    
     const handleChangeBlankLabel = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const text = event.target.value.trim()
+        const text = event.target.value
+        if (text !== '' && !normalizedThemes.includes(text.toLowerCase())) {
+            setCanAdd(true)
+        } else {
+            setCanAdd(false)
+        }
         const color = text.length < 3 ? defaultColor : getColorForTheme(text)
         setNewTheme({color, text})
     }
 
     const handleAddTheme = () => {
+        if (!canAdd) return
         addTheme(newTheme.text)
         setNewTheme({text: '', color: ''})
+        setCanAdd(false)
     }
 
     const handleCloseBlankLabel = () => {
         setShowBlankLabel(false)
         setNewTheme({text: '', color: ''})
+        setCanAdd(false)
     }
 
     const { isExtraLarge } = useScreenSize()
@@ -51,7 +61,7 @@ export default function BlankLabel ({
                 >    
                     x
                 </button>
-                {newTheme.text !== '' &&
+                {canAdd &&
                 <button 
                     type='button'
                     onClick={handleAddTheme}   


### PR DESCRIPTION
Normalized saved themes in dream form to allow matching to be case insensitive
Removed trim from add theme to allow themes to be more than one word
Added logic to BlankLabel to prevent duplicate themes on dream page