### PR TITLE
Fix: login guest auth state

### DIFF
--- a/src/components/home/LandingPage.tsx
+++ b/src/components/home/LandingPage.tsx
@@ -8,7 +8,6 @@ import Button from "../forms/Button"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {faGithub, faLinkedin} from "@fortawesome/free-brands-svg-icons"
 import LoadingSpinner from "../ui/LoadingSpinner"
-
 export default function LandingPage(){
 
     const router = useRouter()
@@ -31,7 +30,8 @@ export default function LandingPage(){
     async function handleLoginGuest() {
         try {
             await loginGuest()
-            router.replace("/dreams")
+            // Force full reload to ensure auth state is available before protected route loads
+            window.location.href = "/dreams"
         } catch (err){
             console.log(err)
         }


### PR DESCRIPTION
Updated handleLoginGuest function in landing page to use window.location.href
This forces reload of auth state to ensure user is not redirected to login page