### PR TITLE
Fix - search bar not showing dream when clicked

### DIFF
--- a/src/components/nav/SearchBar.tsx
+++ b/src/components/nav/SearchBar.tsx
@@ -22,7 +22,8 @@ export default function SearchBar() {
         setChronView(false)
         setSearch('')
     }
-    
+
+
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
             if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
@@ -30,10 +31,10 @@ export default function SearchBar() {
             }
         }
 
-        document.addEventListener('mousedown', handleClickOutside)
+        document.addEventListener('click', handleClickOutside)
 
         return () => {
-            document.removeEventListener('mousedown', handleClickOutside)
+            document.removeEventListener('click', handleClickOutside)
         }
     }, [setSearch])
 


### PR DESCRIPTION
Updated search bar event listener to use 'click' instead of 'onmousedown' 
Dream can now be displayed and search results are hidden if clicked elsewhere