### PR TITLE
Fix dreamlist scrollbar

### DIFF
--- a/src/components/nav/DreamsList.tsx
+++ b/src/components/nav/DreamsList.tsx
@@ -40,10 +40,10 @@ export default function DreamsList(){
         loadingCounts ? <LoadingSpinner /> :
         <div className={`rounded mt-1 ${view === 'dreams' ? 'ml-1':''} bg-white/60 hover:bg-white ${ isMedium ? 'border border-gray-200 p-2' : ''}`}>
             <div className="grid grid-cols-10">
-                <div className="col-span-7 flex justify-start text-sm text-gray-500">
+                <div className={`${view === 'dreams' ? 'col-span-7' : 'col-span-6'} flex justify-start text-sm text-gray-500`}>
                     {isMedium? 'Dreams' : 'Dream:'} {!loadingDreams && isMedium && `(${dreamsList.length}):`}
                 </div>
-                <div className="col-span-3 -ml-2 flex items-center justify-start text-sm text-gray-500">
+                <div className={`${view === 'dreams' ? 'col-span-3' : 'col-span-4'} flex items-center justify-start text-sm text-gray-500`}>
                     Date: 
                     {dreamsList.length > 1 && view === 'dreams' &&
                         <IconWithTooltip 
@@ -54,17 +54,17 @@ export default function DreamsList(){
                     }
                 </div>
             </div>
-            <div className="grid grid-cols-10 max-h-32 overflow-y-auto scrollbar-custom">
+            <div className="grid grid-cols-10 max-h-32 overflow-y-scroll scrollbar-custom">
                 {dreamsList.map(dream => (
                     <div key={dream._id} className="contents row-span-full">
-                        <div onClick={() => handleClick(dream._id)} className="truncate pr-1 col-span-7 hover:underline cursor-pointer">
+                        <div className={`truncate pr-1 ${view === 'dreams' ? 'col-span-7' : 'col-span-6'} hover:underline cursor-pointer`} onClick={() => handleClick(dream._id)}>
                             {dream.title}
                         </div> 
                         {view === 'themes' ? 
-                            <div className='col-span-3 pt-1 text-gray-500 text-xs'>
+                            <div className='col-span-4 pl-2 pt-1 text-gray-500 text-xs'>
                                 {formatDate(dream.date, true, true)} 
                             </div>                            
-                        :   <div className='col-span-3 flex items-center justify-start pt-1 text-sm'>
+                        :   <div className='col-span-3 pl-2 flex items-center justify-start pt-1 text-sm'>
                                 {formatDate(dream.date, true)}
                             </div> 
                         }


### PR DESCRIPTION
Updated overflow-y from auto to scroll to ensure scrollbar is always present
This prevents scrollbar from shifting content left
The styling scrollbar-gutter: stable is already applied, but this is inconsistent across browsers
